### PR TITLE
Minor Tinkers Construct Integration

### DIFF
--- a/src/main/java/ganymedes01/ganyssurface/integration/TConstruct.java
+++ b/src/main/java/ganymedes01/ganyssurface/integration/TConstruct.java
@@ -1,0 +1,71 @@
+package ganymedes01.ganyssurface.integration;
+
+import ganymedes01.ganyssurface.GanysSurface;
+import ganymedes01.ganyssurface.ModBlocks;
+import ganymedes01.ganyssurface.ModItems;
+import net.minecraft.nbt.NBTTagCompound;
+import cpw.mods.fml.common.event.FMLInterModComms;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.block.Block;
+import net.minecraft.item.ItemStack;
+import net.minecraft.init.Blocks;
+import net.minecraft.init.Items;
+
+/**
+ * TConstuct integration for modified iron/trap doors
+ * integration by ezterry, full unrestricted rights of this code document
+ * are released to ganymedes01 for use in Gany's Surface and/or
+ * other projects
+ *
+ */
+
+//update TiC recipes to match new iron doors
+public class TConstruct extends Integration {
+
+	@Override
+	public void init() {
+		// NOP
+
+	}
+
+	@Override
+	public void postInit() {
+		NBTTagCompound data;
+		int ingotLiquidValue = 144; //1 ingot amount in mb
+
+		ItemStack iron = new ItemStack(Blocks.iron_block);
+
+		if(GanysSurface.enableDoors){
+			//reload the door melting recipe (will overwrite)
+			ItemStack iron_door = new ItemStack(Items.iron_door);
+			data = new NBTTagCompound();
+
+			data.setString("FluidName", "iron.molten");
+			data.setInteger("Amount", ingotLiquidValue * 2);
+			data.setInteger("Temperature", 600);
+			data.setTag("Item", iron_door.writeToNBT(new NBTTagCompound()));
+			data.setTag("Block", iron.writeToNBT(new NBTTagCompound()));
+
+			FMLInterModComms.sendMessage(getModID(), "addSmelteryMelting", data);
+		}
+		if(GanysSurface.enableIronTrapdoor){
+			//add a trapdoor smelting recipe
+			ItemStack iron_trapdoor = new ItemStack(ModBlocks.ironTrapdoor);
+			data = new NBTTagCompound();
+
+			data.setString("FluidName", "iron.molten");
+			data.setInteger("Amount", ingotLiquidValue * 4);
+			data.setInteger("Temperature", 600);
+			data.setTag("Item", iron_trapdoor.writeToNBT(new NBTTagCompound()));
+			data.setTag("Block", iron.writeToNBT(new NBTTagCompound()));
+
+			FMLInterModComms.sendMessage(getModID(), "addSmelteryMelting", data);
+		}
+	}
+
+	@Override
+	public String getModID() {
+		return "TConstruct";
+	}
+
+}


### PR DESCRIPTION
* Fixes Iron Duplication bug between TConstruct & Gany's Surface:
Modified Iron Door recipe is 6 ingots for 3 doors,
TConstuct smelting is 6 ingots for 1 door, this reduces it to 2 ingots.

* Adds smelting recipe for iron trap doors (give 4 ingots worth of
liquid iron)