### PR TITLE
Removed super call on onNeighborBlockChange

### DIFF
--- a/src/main/java/ganymedes01/ganyssurface/blocks/BlockWoodSign.java
+++ b/src/main/java/ganymedes01/ganyssurface/blocks/BlockWoodSign.java
@@ -119,8 +119,6 @@ public class BlockWoodSign extends BlockSign implements ISubBlocksBlock, IConfig
 			this.dropBlockAsItem(world, x, y, z, world.getBlockMetadata(x, y, z), 0);
 			world.setBlockToAir(x, y, z);
 		}
-
-		super.onNeighborBlockChange(world, x, y, z, neighbour);
 	}
 
 	@Override


### PR DESCRIPTION
This makes sign blocks not check the super method for breaking, which would not bother checking the TE for whether the block is standing up or not, breaking it.
Closes #72
